### PR TITLE
- new automatic decimal rounding

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Key Features:
 - Array and structure support: Arrays and structures can be mixed, building arbitrary data
   structures.
 - Uses BigDecimal for numerical calculations.
+- MathContext and number of decimal places can be configured, with automatic rounding.
 - No dependencies to external libraries.
 - Easy integration into existing systems to access data.
 - Standard boolean and mathematical operators.

--- a/src/main/java/com/ezylang/evalex/config/ExpressionConfiguration.java
+++ b/src/main/java/com/ezylang/evalex/config/ExpressionConfiguration.java
@@ -147,6 +147,9 @@ public class ExpressionConfiguration {
   public static final Map<String, EvaluationValue> StandardConstants =
       Collections.unmodifiableMap(getStandardConstants());
 
+  /** Setting the decimal places to unlimited, will disable intermediate rounding. */
+  public static final int DECIMAL_PLACES_ROUNDING_UNLIMITED = -1;
+
   private static Map<String, EvaluationValue> getStandardConstants() {
 
     Map<String, EvaluationValue> constants = new HashMap<>();
@@ -218,6 +221,12 @@ public class ExpressionConfiguration {
    * OperatorIfc#OPERATOR_PRECEDENCE_POWER_HIGHER} or to a custom value.
    */
   @Builder.Default @Getter private int powerOfPrecedence = OperatorIfc.OPERATOR_PRECEDENCE_POWER;
+
+  /**
+   * If specified, all results from operations and functions will be rounded to the specified number
+   * of decimal digits, using the MathContexts rounding mode.
+   */
+  @Builder.Default @Getter private int decimalPlacesRounding = DECIMAL_PLACES_ROUNDING_UNLIMITED;
 
   /**
    * Convenience method to create a default configuration.

--- a/src/test/java/com/ezylang/evalex/BaseEvaluationTest.java
+++ b/src/test/java/com/ezylang/evalex/BaseEvaluationTest.java
@@ -15,17 +15,18 @@
 */
 package com.ezylang.evalex;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.ezylang.evalex.config.ExpressionConfiguration;
 import com.ezylang.evalex.config.TestConfigurationProvider;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.parser.ParseException;
-import org.assertj.core.api.Assertions;
 
 public abstract class BaseEvaluationTest {
 
   protected void assertExpressionHasExpectedResult(String expression, String expectedResult)
       throws EvaluationException, ParseException {
-    Assertions.assertThat(
+    assertThat(
             evaluate(
                     expression,
                     TestConfigurationProvider.StandardConfigurationWithAdditionalTestOperators)
@@ -36,7 +37,7 @@ public abstract class BaseEvaluationTest {
   protected void assertExpressionHasExpectedResult(
       String expression, String expectedResult, ExpressionConfiguration expressionConfiguration)
       throws EvaluationException, ParseException {
-    Assertions.assertThat(evaluate(expression, expressionConfiguration).getStringValue())
+    assertThat(evaluate(expression, expressionConfiguration).getStringValue())
         .isEqualTo(expectedResult);
   }
 

--- a/src/test/java/com/ezylang/evalex/ExpressionEvaluationExceptionsTest.java
+++ b/src/test/java/com/ezylang/evalex/ExpressionEvaluationExceptionsTest.java
@@ -15,10 +15,11 @@
 */
 package com.ezylang.evalex;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.ezylang.evalex.parser.ASTNode;
 import com.ezylang.evalex.parser.Token;
 import com.ezylang.evalex.parser.Token.TokenType;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class ExpressionEvaluationExceptionsTest {
@@ -27,7 +28,7 @@ class ExpressionEvaluationExceptionsTest {
   void testUnexpectedToken() {
     Expression expression = new Expression("1");
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> {
               ASTNode node = new ASTNode(new Token(1, "(", TokenType.BRACE_OPEN));
               expression.evaluateSubtree(node);

--- a/src/test/java/com/ezylang/evalex/ExpressionEvaluatorDecimalPlacesTest.java
+++ b/src/test/java/com/ezylang/evalex/ExpressionEvaluatorDecimalPlacesTest.java
@@ -1,0 +1,151 @@
+/*
+  Copyright 2012-2022 Udo Klimaschewski
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+package com.ezylang.evalex;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ezylang.evalex.config.ExpressionConfiguration;
+import com.ezylang.evalex.parser.ParseException;
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ExpressionEvaluatorDecimalPlacesTest extends BaseExpressionEvaluatorTest {
+
+  @Test
+  void testDefaultNoRoundingLiteral() throws ParseException, EvaluationException {
+    assertThat(evaluate("2.12345")).isEqualTo("2.12345");
+  }
+
+  @Test
+  void testDefaultNoRoundingVariable() throws ParseException, EvaluationException {
+    Expression expression = new Expression("a").with("a", new BigDecimal("2.12345"));
+
+    assertThat(expression.evaluate().getStringValue()).isEqualTo("2.12345");
+  }
+
+  @Test
+  void testDefaultNoRoundingInfixOperator() throws ParseException, EvaluationException {
+    assertThat(evaluate("2.12345+1.54321")).isEqualTo("3.66666");
+  }
+
+  @Test
+  void testDefaultNoRoundingPrefixOperator() throws ParseException, EvaluationException {
+    assertThat(evaluate("-2.12345")).isEqualTo("-2.12345");
+  }
+
+  @Test
+  void testDefaultNoRoundingFunction() throws ParseException, EvaluationException {
+    assertThat(evaluate("SUM(2.12345,1.54321)")).isEqualTo("3.66666");
+  }
+
+  @Test
+  void testDefaultNoRoundingArray() throws ParseException, EvaluationException {
+    List<BigDecimal> array = List.of(new BigDecimal("1.12345"));
+    Expression expression = createExpression("a[0]").with("a", array);
+
+    assertThat(expression.evaluate().getStringValue()).isEqualTo("1.12345");
+  }
+
+  @Test
+  void testDefaultNoRoundingStructure() throws ParseException, EvaluationException {
+    Map<String, BigDecimal> structure =
+        new HashMap<>() {
+          {
+            put("b", new BigDecimal("1.12345"));
+          }
+        };
+
+    Expression expression = createExpression("a.b").with("a", structure);
+
+    assertThat(expression.evaluate().getStringValue()).isEqualTo("1.12345");
+  }
+
+  @Test
+  void testCustomRoundingDecimalsLiteral() throws ParseException, EvaluationException {
+    ExpressionConfiguration config =
+        ExpressionConfiguration.builder().decimalPlacesRounding(2).build();
+    Expression expression = new Expression("2.12345", config);
+
+    assertThat(expression.evaluate().getStringValue()).isEqualTo("2.12");
+  }
+
+  @Test
+  void testCustomRoundingDecimalsVariable() throws ParseException, EvaluationException {
+    ExpressionConfiguration config =
+        ExpressionConfiguration.builder().decimalPlacesRounding(2).build();
+    Expression expression = new Expression("a", config).with("a", new BigDecimal("2.126"));
+
+    assertThat(expression.evaluate().getStringValue()).isEqualTo("2.13");
+  }
+
+  @Test
+  void testCustomRoundingDecimalsInfixOperator() throws ParseException, EvaluationException {
+    ExpressionConfiguration config =
+        ExpressionConfiguration.builder().decimalPlacesRounding(3).build();
+    Expression expression = new Expression("2.12345+1.54321", config);
+
+    // literals are rounded first, the added and rounded again.
+    assertThat(expression.evaluate().getStringValue()).isEqualTo("3.666");
+  }
+
+  @Test
+  void testCustomRoundingDecimalsPrefixOperator() throws ParseException, EvaluationException {
+    ExpressionConfiguration config =
+        ExpressionConfiguration.builder().decimalPlacesRounding(3).build();
+    Expression expression = new Expression("-2.12345", config);
+
+    assertThat(expression.evaluate().getStringValue()).isEqualTo("-2.123");
+  }
+
+  @Test
+  void testCustomRoundingDecimalsFunction() throws ParseException, EvaluationException {
+    ExpressionConfiguration config =
+        ExpressionConfiguration.builder().decimalPlacesRounding(3).build();
+    Expression expression = new Expression("SUM(2.12345,1.54321)", config);
+
+    // literals are rounded first, the added and rounded again.
+    assertThat(expression.evaluate().getStringValue()).isEqualTo("3.666");
+  }
+
+  @Test
+  void testCustomRoundingDecimalsArray() throws ParseException, EvaluationException {
+    ExpressionConfiguration config =
+        ExpressionConfiguration.builder().decimalPlacesRounding(3).build();
+    List<BigDecimal> array = List.of(new BigDecimal("1.12345"));
+    Expression expression = new Expression("a[0]", config).with("a", array);
+
+    assertThat(expression.evaluate().getStringValue()).isEqualTo("1.123");
+  }
+
+  @Test
+  void testCustomRoundingStructure() throws ParseException, EvaluationException {
+    ExpressionConfiguration config =
+        ExpressionConfiguration.builder().decimalPlacesRounding(3).build();
+    Map<String, BigDecimal> structure =
+        new HashMap<>() {
+          {
+            put("b", new BigDecimal("1.12345"));
+          }
+        };
+
+    Expression expression = new Expression("a.b", config).with("a", structure);
+
+    assertThat(expression.evaluate().getStringValue()).isEqualTo("1.123");
+  }
+}

--- a/src/test/java/com/ezylang/evalex/config/ExpressionConfigurationTest.java
+++ b/src/test/java/com/ezylang/evalex/config/ExpressionConfigurationTest.java
@@ -49,6 +49,8 @@ class ExpressionConfigurationTest {
         .isEqualTo(OperatorIfc.OPERATOR_PRECEDENCE_POWER);
     assertThat(configuration.getDefaultConstants())
         .containsAllEntriesOf(ExpressionConfiguration.StandardConstants);
+    assertThat(configuration.getDecimalPlacesRounding())
+        .isEqualTo(ExpressionConfiguration.DECIMAL_PLACES_ROUNDING_UNLIMITED);
   }
 
   @Test

--- a/src/test/java/com/ezylang/evalex/config/MapBasedFunctionDictionaryTest.java
+++ b/src/test/java/com/ezylang/evalex/config/MapBasedFunctionDictionaryTest.java
@@ -15,11 +15,12 @@
 */
 package com.ezylang.evalex.config;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.ezylang.evalex.functions.FunctionIfc;
 import com.ezylang.evalex.functions.basic.MaxFunction;
 import com.ezylang.evalex.functions.basic.MinFunction;
 import java.util.Map;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class MapBasedFunctionDictionaryTest {
@@ -33,13 +34,13 @@ class MapBasedFunctionDictionaryTest {
     FunctionDictionaryIfc dictionary =
         MapBasedFunctionDictionary.ofFunctions(Map.entry("min", min), Map.entry("max", max));
 
-    Assertions.assertThat(dictionary.hasFunction("min")).isTrue();
-    Assertions.assertThat(dictionary.hasFunction("max")).isTrue();
+    assertThat(dictionary.hasFunction("min")).isTrue();
+    assertThat(dictionary.hasFunction("max")).isTrue();
 
-    Assertions.assertThat(dictionary.getFunction("min")).isEqualTo(min);
-    Assertions.assertThat(dictionary.getFunction("max")).isEqualTo(max);
+    assertThat(dictionary.getFunction("min")).isEqualTo(min);
+    assertThat(dictionary.getFunction("max")).isEqualTo(max);
 
-    Assertions.assertThat(dictionary.hasFunction("medium")).isFalse();
+    assertThat(dictionary.hasFunction("medium")).isFalse();
   }
 
   @Test
@@ -51,11 +52,11 @@ class MapBasedFunctionDictionaryTest {
     FunctionDictionaryIfc dictionary =
         MapBasedFunctionDictionary.ofFunctions(Map.entry("Min", min), Map.entry("MAX", max));
 
-    Assertions.assertThat(dictionary.hasFunction("min")).isTrue();
-    Assertions.assertThat(dictionary.hasFunction("MIN")).isTrue();
-    Assertions.assertThat(dictionary.hasFunction("Min")).isTrue();
-    Assertions.assertThat(dictionary.hasFunction("max")).isTrue();
-    Assertions.assertThat(dictionary.hasFunction("MAX")).isTrue();
-    Assertions.assertThat(dictionary.hasFunction("Max")).isTrue();
+    assertThat(dictionary.hasFunction("min")).isTrue();
+    assertThat(dictionary.hasFunction("MIN")).isTrue();
+    assertThat(dictionary.hasFunction("Min")).isTrue();
+    assertThat(dictionary.hasFunction("max")).isTrue();
+    assertThat(dictionary.hasFunction("MAX")).isTrue();
+    assertThat(dictionary.hasFunction("Max")).isTrue();
   }
 }

--- a/src/test/java/com/ezylang/evalex/config/MapBasedOperatorDictionaryTest.java
+++ b/src/test/java/com/ezylang/evalex/config/MapBasedOperatorDictionaryTest.java
@@ -15,12 +15,13 @@
 */
 package com.ezylang.evalex.config;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.ezylang.evalex.config.TestConfigurationProvider.PostfixQuestionOperator;
 import com.ezylang.evalex.config.TestConfigurationProvider.PrefixPlusPlusOperator;
 import com.ezylang.evalex.operators.OperatorIfc;
 import com.ezylang.evalex.operators.arithmetic.InfixModuloOperator;
 import java.util.Map;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class MapBasedOperatorDictionaryTest {
@@ -36,17 +37,17 @@ class MapBasedOperatorDictionaryTest {
         MapBasedOperatorDictionary.ofOperators(
             Map.entry("++", prefix), Map.entry("?", postfix), Map.entry("%", infix));
 
-    Assertions.assertThat(dictionary.hasPrefixOperator("++")).isTrue();
-    Assertions.assertThat(dictionary.hasPostfixOperator("?")).isTrue();
-    Assertions.assertThat(dictionary.hasInfixOperator("%")).isTrue();
+    assertThat(dictionary.hasPrefixOperator("++")).isTrue();
+    assertThat(dictionary.hasPostfixOperator("?")).isTrue();
+    assertThat(dictionary.hasInfixOperator("%")).isTrue();
 
-    Assertions.assertThat(dictionary.getPrefixOperator("++")).isEqualTo(prefix);
-    Assertions.assertThat(dictionary.getPostfixOperator("?")).isEqualTo(postfix);
-    Assertions.assertThat(dictionary.getInfixOperator("%")).isEqualTo(infix);
+    assertThat(dictionary.getPrefixOperator("++")).isEqualTo(prefix);
+    assertThat(dictionary.getPostfixOperator("?")).isEqualTo(postfix);
+    assertThat(dictionary.getInfixOperator("%")).isEqualTo(infix);
 
-    Assertions.assertThat(dictionary.hasPrefixOperator("A")).isFalse();
-    Assertions.assertThat(dictionary.hasPostfixOperator("B")).isFalse();
-    Assertions.assertThat(dictionary.hasInfixOperator("C")).isFalse();
+    assertThat(dictionary.hasPrefixOperator("A")).isFalse();
+    assertThat(dictionary.hasPostfixOperator("B")).isFalse();
+    assertThat(dictionary.hasInfixOperator("C")).isFalse();
   }
 
   @Test
@@ -62,16 +63,16 @@ class MapBasedOperatorDictionaryTest {
             Map.entry("Question", postfix),
             Map.entry("Percent", infix));
 
-    Assertions.assertThat(dictionary.hasPrefixOperator("PlusPlus")).isTrue();
-    Assertions.assertThat(dictionary.hasPrefixOperator("plusplus")).isTrue();
-    Assertions.assertThat(dictionary.hasPrefixOperator("PLUSPLUS")).isTrue();
+    assertThat(dictionary.hasPrefixOperator("PlusPlus")).isTrue();
+    assertThat(dictionary.hasPrefixOperator("plusplus")).isTrue();
+    assertThat(dictionary.hasPrefixOperator("PLUSPLUS")).isTrue();
 
-    Assertions.assertThat(dictionary.hasPostfixOperator("Question")).isTrue();
-    Assertions.assertThat(dictionary.hasPostfixOperator("question")).isTrue();
-    Assertions.assertThat(dictionary.hasPostfixOperator("QUESTION")).isTrue();
+    assertThat(dictionary.hasPostfixOperator("Question")).isTrue();
+    assertThat(dictionary.hasPostfixOperator("question")).isTrue();
+    assertThat(dictionary.hasPostfixOperator("QUESTION")).isTrue();
 
-    Assertions.assertThat(dictionary.hasInfixOperator("Percent")).isTrue();
-    Assertions.assertThat(dictionary.hasInfixOperator("percent")).isTrue();
-    Assertions.assertThat(dictionary.hasInfixOperator("PERCENT")).isTrue();
+    assertThat(dictionary.hasInfixOperator("Percent")).isTrue();
+    assertThat(dictionary.hasInfixOperator("percent")).isTrue();
+    assertThat(dictionary.hasInfixOperator("PERCENT")).isTrue();
   }
 }

--- a/src/test/java/com/ezylang/evalex/operators/arithmetic/ArithmeticOperatorsTest.java
+++ b/src/test/java/com/ezylang/evalex/operators/arithmetic/ArithmeticOperatorsTest.java
@@ -15,10 +15,11 @@
 */
 package com.ezylang.evalex.operators.arithmetic;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.ezylang.evalex.BaseEvaluationTest;
 import com.ezylang.evalex.EvaluationException;
 import com.ezylang.evalex.parser.ParseException;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -43,7 +44,7 @@ class ArithmeticOperatorsTest extends BaseEvaluationTest {
         "+\"string\""
       })
   void testUnsupportedDataType(String expression) {
-    Assertions.assertThatThrownBy(() -> assertExpressionHasExpectedResult(expression, "0"))
+    assertThatThrownBy(() -> assertExpressionHasExpectedResult(expression, "0"))
         .isInstanceOf(EvaluationException.class)
         .hasMessage("Unsupported data types in operation");
   }
@@ -66,7 +67,7 @@ class ArithmeticOperatorsTest extends BaseEvaluationTest {
 
   @Test
   void testInfixDivisionByZero() {
-    Assertions.assertThatThrownBy(() -> assertExpressionHasExpectedResult("3/0", "0"))
+    assertThatThrownBy(() -> assertExpressionHasExpectedResult("3/0", "0"))
         .isInstanceOf(EvaluationException.class)
         .hasMessage("Division by zero");
   }
@@ -107,7 +108,7 @@ class ArithmeticOperatorsTest extends BaseEvaluationTest {
 
   @Test
   void testInfixModuloByZero() {
-    Assertions.assertThatThrownBy(() -> assertExpressionHasExpectedResult("3%0", "0"))
+    assertThatThrownBy(() -> assertExpressionHasExpectedResult("3%0", "0"))
         .isInstanceOf(EvaluationException.class)
         .hasMessage("Division by zero");
   }

--- a/src/test/java/com/ezylang/evalex/parser/ASTNodeTest.java
+++ b/src/test/java/com/ezylang/evalex/parser/ASTNodeTest.java
@@ -15,11 +15,12 @@
 */
 package com.ezylang.evalex.parser;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.ezylang.evalex.functions.basic.MinFunction;
 import com.ezylang.evalex.operators.arithmetic.InfixPlusOperator;
 import com.ezylang.evalex.operators.arithmetic.PrefixMinusOperator;
 import com.ezylang.evalex.parser.Token.TokenType;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class ASTNodeTest {
@@ -29,7 +30,7 @@ class ASTNodeTest {
   void testJSONSingle() {
     ASTNode node = new ASTNode(variable);
 
-    Assertions.assertThat(node.toJSON())
+    assertThat(node.toJSON())
         .isEqualTo("{\"type\":\"VARIABLE_OR_CONSTANT\",\"value\":\"variable\"}");
   }
 
@@ -38,7 +39,7 @@ class ASTNodeTest {
     Token token = new Token(1, "-", TokenType.PREFIX_OPERATOR, new PrefixMinusOperator());
     ASTNode node = new ASTNode(token, new ASTNode(variable));
 
-    Assertions.assertThat(node.toJSON())
+    assertThat(node.toJSON())
         .isEqualTo(
             "{\"type\":\"PREFIX_OPERATOR\",\"value\":\"-\",\"children\":[{\"type\":\"VARIABLE_OR_CONSTANT\",\"value\":\"variable\"}]}");
   }
@@ -48,7 +49,7 @@ class ASTNodeTest {
     Token token = new Token(1, "+", TokenType.INFIX_OPERATOR, new InfixPlusOperator());
     ASTNode node = new ASTNode(token, new ASTNode(variable), new ASTNode(variable));
 
-    Assertions.assertThat(node.toJSON())
+    assertThat(node.toJSON())
         .isEqualTo(
             "{\"type\":\"INFIX_OPERATOR\",\"value\":\"+\",\"children\":[{\"type\":\"VARIABLE_OR_CONSTANT\",\"value\":\"variable\"},{\"type\":\"VARIABLE_OR_CONSTANT\",\"value\":\"variable\"}]}");
   }
@@ -59,7 +60,7 @@ class ASTNodeTest {
     ASTNode node =
         new ASTNode(token, new ASTNode(variable), new ASTNode(variable), new ASTNode(variable));
 
-    Assertions.assertThat(node.toJSON())
+    assertThat(node.toJSON())
         .isEqualTo(
             "{\"type\":\"FUNCTION\",\"value\":\"+\",\"children\":[{\"type\":\"VARIABLE_OR_CONSTANT\",\"value\":\"variable\"},{\"type\":\"VARIABLE_OR_CONSTANT\",\"value\":\"variable\"},{\"type\":\"VARIABLE_OR_CONSTANT\",\"value\":\"variable\"}]}");
   }

--- a/src/test/java/com/ezylang/evalex/parser/ShuntingYardExceptionsTest.java
+++ b/src/test/java/com/ezylang/evalex/parser/ShuntingYardExceptionsTest.java
@@ -21,13 +21,13 @@ import static com.ezylang.evalex.parser.Token.TokenType.POSTFIX_OPERATOR;
 import static com.ezylang.evalex.parser.Token.TokenType.PREFIX_OPERATOR;
 import static com.ezylang.evalex.parser.Token.TokenType.STRUCTURE_SEPARATOR;
 import static com.ezylang.evalex.parser.Token.TokenType.VARIABLE_OR_CONSTANT;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.operators.arithmetic.InfixMultiplicationOperator;
 import com.ezylang.evalex.operators.arithmetic.PrefixMinusOperator;
 import java.util.Arrays;
 import java.util.List;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class ShuntingYardExceptionsTest extends BaseParserTest {
@@ -35,8 +35,7 @@ class ShuntingYardExceptionsTest extends BaseParserTest {
   @Test
   void testUnexpectedToken() {
     List<Token> tokens = List.of(new Token(1, "x", FUNCTION_PARAM_START));
-    Assertions.assertThatThrownBy(
-            new ShuntingYardConverter("x", tokens, configuration)::toAbstractSyntaxTree)
+    assertThatThrownBy(new ShuntingYardConverter("x", tokens, configuration)::toAbstractSyntaxTree)
         .isInstanceOf(ParseException.class)
         .hasMessage("Unexpected token of type 'FUNCTION_PARAM_START'");
   }
@@ -44,8 +43,7 @@ class ShuntingYardExceptionsTest extends BaseParserTest {
   @Test
   void testMissingPrefixOperand() {
     List<Token> tokens = List.of(new Token(1, "-", PREFIX_OPERATOR, new PrefixMinusOperator()));
-    Assertions.assertThatThrownBy(
-            new ShuntingYardConverter("-", tokens, configuration)::toAbstractSyntaxTree)
+    assertThatThrownBy(new ShuntingYardConverter("-", tokens, configuration)::toAbstractSyntaxTree)
         .isInstanceOf(ParseException.class)
         .hasMessage("Missing operand for operator");
   }
@@ -56,8 +54,7 @@ class ShuntingYardExceptionsTest extends BaseParserTest {
         Arrays.asList(
             new Token(1, "2", VARIABLE_OR_CONSTANT),
             new Token(2, "*", INFIX_OPERATOR, new InfixMultiplicationOperator()));
-    Assertions.assertThatThrownBy(
-            new ShuntingYardConverter("2*", tokens, configuration)::toAbstractSyntaxTree)
+    assertThatThrownBy(new ShuntingYardConverter("2*", tokens, configuration)::toAbstractSyntaxTree)
         .isInstanceOf(ParseException.class)
         .hasMessage("Missing second operand for operator");
   }
@@ -66,7 +63,7 @@ class ShuntingYardExceptionsTest extends BaseParserTest {
   void testEmptyExpression() {
     Expression expression = new Expression("");
 
-    Assertions.assertThatThrownBy(expression::evaluate)
+    assertThatThrownBy(expression::evaluate)
         .isInstanceOf(ParseException.class)
         .hasMessage("Empty expression");
   }
@@ -75,7 +72,7 @@ class ShuntingYardExceptionsTest extends BaseParserTest {
   void testEmptyExpressionBraces() {
     Expression expression = new Expression("()");
 
-    Assertions.assertThatThrownBy(expression::evaluate)
+    assertThatThrownBy(expression::evaluate)
         .isInstanceOf(ParseException.class)
         .hasMessage("Empty expression");
   }
@@ -84,8 +81,7 @@ class ShuntingYardExceptionsTest extends BaseParserTest {
   void testDoubleStructureOperator() {
     List<Token> tokens =
         List.of(new Token(1, ".", STRUCTURE_SEPARATOR), new Token(2, ".", STRUCTURE_SEPARATOR));
-    Assertions.assertThatThrownBy(
-            new ShuntingYardConverter("..", tokens, configuration)::toAbstractSyntaxTree)
+    assertThatThrownBy(new ShuntingYardConverter("..", tokens, configuration)::toAbstractSyntaxTree)
         .isInstanceOf(ParseException.class)
         .hasMessage("Missing operand for operator");
   }
@@ -94,8 +90,7 @@ class ShuntingYardExceptionsTest extends BaseParserTest {
   void testStructureFollowsPostfixOperator() {
     List<Token> tokens =
         List.of(new Token(1, ".", STRUCTURE_SEPARATOR), new Token(2, "!", POSTFIX_OPERATOR));
-    Assertions.assertThatThrownBy(
-            new ShuntingYardConverter("..", tokens, configuration)::toAbstractSyntaxTree)
+    assertThatThrownBy(new ShuntingYardConverter("..", tokens, configuration)::toAbstractSyntaxTree)
         .isInstanceOf(ParseException.class)
         .hasMessage("Missing operand for operator");
   }
@@ -107,8 +102,7 @@ class ShuntingYardExceptionsTest extends BaseParserTest {
             new Token(1, ".", STRUCTURE_SEPARATOR),
             new Token(2, "!", POSTFIX_OPERATOR),
             new Token(2, "!", POSTFIX_OPERATOR));
-    Assertions.assertThatThrownBy(
-            new ShuntingYardConverter("..", tokens, configuration)::toAbstractSyntaxTree)
+    assertThatThrownBy(new ShuntingYardConverter("..", tokens, configuration)::toAbstractSyntaxTree)
         .isInstanceOf(ParseException.class)
         .hasMessage("Missing operand for operator");
   }

--- a/src/test/java/com/ezylang/evalex/parser/ShuntingYardStructureTest.java
+++ b/src/test/java/com/ezylang/evalex/parser/ShuntingYardStructureTest.java
@@ -15,8 +15,9 @@
 */
 package com.ezylang.evalex.parser;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.ezylang.evalex.Expression;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class ShuntingYardStructureTest extends BaseParserTest {
@@ -45,7 +46,7 @@ class ShuntingYardStructureTest extends BaseParserTest {
   @Test
   void testExceptionStructureEnd() {
     Expression expression = new Expression("a.");
-    Assertions.assertThatThrownBy(expression::getAbstractSyntaxTree)
+    assertThatThrownBy(expression::getAbstractSyntaxTree)
         .isInstanceOf(ParseException.class)
         .hasMessage("Missing second operand for operator");
   }
@@ -53,7 +54,7 @@ class ShuntingYardStructureTest extends BaseParserTest {
   @Test
   void testExceptionStructureStart() {
     Expression expression = new Expression(".a");
-    Assertions.assertThatThrownBy(expression::getAbstractSyntaxTree)
+    assertThatThrownBy(expression::getAbstractSyntaxTree)
         .isInstanceOf(ParseException.class)
         .hasMessage("Structure separator not allowed here");
   }

--- a/src/test/java/com/ezylang/evalex/parser/TokenizerArrayTest.java
+++ b/src/test/java/com/ezylang/evalex/parser/TokenizerArrayTest.java
@@ -15,9 +15,10 @@
 */
 package com.ezylang.evalex.parser;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.ezylang.evalex.config.ExpressionConfiguration;
 import com.ezylang.evalex.parser.Token.TokenType;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class TokenizerArrayTest extends BaseParserTest {
@@ -52,43 +53,43 @@ class TokenizerArrayTest extends BaseParserTest {
 
   @Test
   void testMissingClosingArray() {
-    Assertions.assertThatThrownBy(() -> new Tokenizer("a[2+4", configuration).parse())
+    assertThatThrownBy(() -> new Tokenizer("a[2+4", configuration).parse())
         .isEqualTo(new ParseException(1, 5, "a[2+4", "Closing array not found"));
   }
 
   @Test
   void testUnexpectedClosingArray() {
-    Assertions.assertThatThrownBy(() -> new Tokenizer("a[2+4]]", configuration).parse())
+    assertThatThrownBy(() -> new Tokenizer("a[2+4]]", configuration).parse())
         .isEqualTo(new ParseException(7, 7, "]", "Unexpected closing array"));
   }
 
   @Test
   void testOpenArrayNotAllowedBeginning() {
-    Assertions.assertThatThrownBy(() -> new Tokenizer("[1]", configuration).parse())
+    assertThatThrownBy(() -> new Tokenizer("[1]", configuration).parse())
         .isEqualTo(new ParseException(1, 1, "[", "Array open not allowed here"));
   }
 
   @Test
   void testOpenArrayNotAllowedAfterOperator() {
-    Assertions.assertThatThrownBy(() -> new Tokenizer("1+[1]", configuration).parse())
+    assertThatThrownBy(() -> new Tokenizer("1+[1]", configuration).parse())
         .isEqualTo(new ParseException(3, 3, "[", "Array open not allowed here"));
   }
 
   @Test
   void testOpenArrayNotAllowedAfterBrace() {
-    Assertions.assertThatThrownBy(() -> new Tokenizer("([1]", configuration).parse())
+    assertThatThrownBy(() -> new Tokenizer("([1]", configuration).parse())
         .isEqualTo(new ParseException(2, 2, "[", "Array open not allowed here"));
   }
 
   @Test
   void testCloseArrayNotAllowedBeginning() {
-    Assertions.assertThatThrownBy(() -> new Tokenizer("]", configuration).parse())
+    assertThatThrownBy(() -> new Tokenizer("]", configuration).parse())
         .isEqualTo(new ParseException(1, 1, "]", "Array close not allowed here"));
   }
 
   @Test
   void testCloseArrayNotAllowedAfterBrace() {
-    Assertions.assertThatThrownBy(() -> new Tokenizer("(]", configuration).parse())
+    assertThatThrownBy(() -> new Tokenizer("(]", configuration).parse())
         .isEqualTo(new ParseException(2, 2, "]", "Array close not allowed here"));
   }
 
@@ -96,7 +97,7 @@ class TokenizerArrayTest extends BaseParserTest {
   void testArraysNotAllowedOpen() {
     ExpressionConfiguration config = ExpressionConfiguration.builder().arraysAllowed(false).build();
 
-    Assertions.assertThatThrownBy(() -> new Tokenizer("a[0]", config).parse())
+    assertThatThrownBy(() -> new Tokenizer("a[0]", config).parse())
         .isEqualTo(new ParseException(2, 2, "[", "Undefined operator '['"));
   }
 
@@ -104,7 +105,7 @@ class TokenizerArrayTest extends BaseParserTest {
   void testArraysNotAllowedClose() {
     ExpressionConfiguration config = ExpressionConfiguration.builder().arraysAllowed(false).build();
 
-    Assertions.assertThatThrownBy(() -> new Tokenizer("]", config).parse())
+    assertThatThrownBy(() -> new Tokenizer("]", config).parse())
         .isEqualTo(new ParseException(1, 1, "]", "Undefined operator ']'"));
   }
 }

--- a/src/test/java/com/ezylang/evalex/parser/TokenizerBracesTest.java
+++ b/src/test/java/com/ezylang/evalex/parser/TokenizerBracesTest.java
@@ -15,8 +15,9 @@
 */
 package com.ezylang.evalex.parser;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.ezylang.evalex.parser.Token.TokenType;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class TokenizerBracesTest extends BaseParserTest {
@@ -50,13 +51,13 @@ class TokenizerBracesTest extends BaseParserTest {
 
   @Test
   void testMissingClosingBrace() {
-    Assertions.assertThatThrownBy(() -> new Tokenizer("(2+4", configuration).parse())
+    assertThatThrownBy(() -> new Tokenizer("(2+4", configuration).parse())
         .isEqualTo(new ParseException(1, 4, "(2+4", "Closing brace not found"));
   }
 
   @Test
   void testUnexpectedClosingBrace() {
-    Assertions.assertThatThrownBy(() -> new Tokenizer("(2+4))", configuration).parse())
+    assertThatThrownBy(() -> new Tokenizer("(2+4))", configuration).parse())
         .isEqualTo(new ParseException(6, 6, ")", "Unexpected closing brace"));
   }
 }

--- a/src/test/java/com/ezylang/evalex/parser/TokenizerExpressionTest.java
+++ b/src/test/java/com/ezylang/evalex/parser/TokenizerExpressionTest.java
@@ -15,8 +15,9 @@
 */
 package com.ezylang.evalex.parser;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.ezylang.evalex.parser.Token.TokenType;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class TokenizerExpressionTest extends BaseParserTest {
@@ -53,7 +54,7 @@ class TokenizerExpressionTest extends BaseParserTest {
 
   @Test
   void testUndefinedOperator() {
-    Assertions.assertThatThrownBy(() -> new Tokenizer("a $ b", configuration).parse())
+    assertThatThrownBy(() -> new Tokenizer("a $ b", configuration).parse())
         .isEqualTo(new ParseException(3, 3, "$", "Undefined operator '$'"));
   }
 }

--- a/src/test/java/com/ezylang/evalex/parser/TokenizerFunctionsTest.java
+++ b/src/test/java/com/ezylang/evalex/parser/TokenizerFunctionsTest.java
@@ -15,9 +15,10 @@
 */
 package com.ezylang.evalex.parser;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.ezylang.evalex.config.TestConfigurationProvider.DummyFunction;
 import com.ezylang.evalex.parser.Token.TokenType;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class TokenizerFunctionsTest extends BaseParserTest {
@@ -135,7 +136,7 @@ class TokenizerFunctionsTest extends BaseParserTest {
 
   @Test
   void testUndefinedFunction() {
-    Assertions.assertThatThrownBy(() -> new Tokenizer("a(b)", configuration).parse())
+    assertThatThrownBy(() -> new Tokenizer("a(b)", configuration).parse())
         .isEqualTo(new ParseException(1, 2, "a", "Undefined function 'a'"));
   }
 }

--- a/src/test/java/com/ezylang/evalex/parser/TokenizerImplicitMultiplicationTest.java
+++ b/src/test/java/com/ezylang/evalex/parser/TokenizerImplicitMultiplicationTest.java
@@ -15,9 +15,10 @@
 */
 package com.ezylang.evalex.parser;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.ezylang.evalex.config.ExpressionConfiguration;
 import com.ezylang.evalex.parser.Token.TokenType;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class TokenizerImplicitMultiplicationTest extends BaseParserTest {
@@ -55,7 +56,7 @@ class TokenizerImplicitMultiplicationTest extends BaseParserTest {
     ExpressionConfiguration config =
         ExpressionConfiguration.builder().implicitMultiplicationAllowed(false).build();
 
-    Assertions.assertThatThrownBy(() -> new Tokenizer("2(x+y)", config).parse())
+    assertThatThrownBy(() -> new Tokenizer("2(x+y)", config).parse())
         .isEqualTo(new ParseException(2, 2, "(", "Missing operator"));
   }
 }

--- a/src/test/java/com/ezylang/evalex/parser/TokenizerStructureTest.java
+++ b/src/test/java/com/ezylang/evalex/parser/TokenizerStructureTest.java
@@ -15,9 +15,10 @@
 */
 package com.ezylang.evalex.parser;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.ezylang.evalex.config.ExpressionConfiguration;
 import com.ezylang.evalex.parser.Token.TokenType;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class TokenizerStructureTest extends BaseParserTest {
@@ -33,13 +34,13 @@ class TokenizerStructureTest extends BaseParserTest {
 
   @Test
   void testStructureSeparatorNotAllowedBegin() {
-    Assertions.assertThatThrownBy(() -> new Tokenizer(".", configuration).parse())
+    assertThatThrownBy(() -> new Tokenizer(".", configuration).parse())
         .isEqualTo(new ParseException(1, 1, ".", "Structure separator not allowed here"));
   }
 
   @Test
   void testStructureSeparatorNotAllowedOperator() {
-    Assertions.assertThatThrownBy(() -> new Tokenizer("-.", configuration).parse())
+    assertThatThrownBy(() -> new Tokenizer("-.", configuration).parse())
         .isEqualTo(new ParseException(2, 2, ".", "Structure separator not allowed here"));
   }
 
@@ -48,7 +49,7 @@ class TokenizerStructureTest extends BaseParserTest {
     ExpressionConfiguration config =
         ExpressionConfiguration.builder().structuresAllowed(false).build();
 
-    Assertions.assertThatThrownBy(() -> new Tokenizer("a.b", config).parse())
+    assertThatThrownBy(() -> new Tokenizer("a.b", config).parse())
         .isEqualTo(new ParseException(2, 2, ".", "Undefined operator '.'"));
   }
 }


### PR DESCRIPTION
For all operations, functions, literals there is a possibility to configure the number of resulting decimal digits.
results will be rounded according to the number of digits and the rounding mode of the MathContext.
```java
  @Test
  void testCustomRoundingDecimalsInfixOperator() throws ParseException, EvaluationException {
    ExpressionConfiguration config =
        ExpressionConfiguration.builder().decimalPlacesRounding(3).build();
    Expression expression = new Expression("2.12345+1.54321", config);

    // literals are rounded first, then added and rounded again.
    assertThat(expression.evaluate().getStringValue()).isEqualTo("3.666");
  }
```